### PR TITLE
Added logging for concurrent tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+test/tmp

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,13 @@
 module.exports = function (grunt) {
 	grunt.initConfig({
 		concurrent: {
-			test: ['test1', 'test2', 'test3']
+			test: ['test1', 'test2', 'test3'],
+			log: {
+				tasks: ['simplemocha'],
+				options: {
+					logConcurrentOutput: true
+				}
+			}
 		},
 		simplemocha: {
 			test: {

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Running slow tasks like Coffee and Sass concurrently can potentially improve you
 
 *Requires grunt 0.4*
 
-This task is similar to grunt-parallel, but more focused by leaving out support for shell scripts which results in a leaner config. It also has a smaller dependency size and pads the output of concurrent tasks, as seen above.
+This task is similar to [grunt-parallel](https://github.com/iammerrick/grunt-parallel), but more focused by leaving out support for shell scripts which results in a leaner config. It also has a smaller dependency size and pads the output of concurrent tasks, as seen above.
 
 
 ## Getting Started
@@ -52,7 +52,19 @@ grunt.loadNpmTasks('grunt-concurrent');
 grunt.registerTask('default', ['concurrent:target1', 'concurrent:target2']);
 ```
 
+### Logging concurrent output
 
+You can optionally log the output of your concurrent tasks by specifying the `logConcurrentOutput` option. Here is an example config which runs [grunt-nodemon](https://github.com/ChrisWren/grunt-nodemon) to launch and monitor a node server and [grunt-contrib-watch](https://github.com/gruntjs/grunt-contrib-watch) to watch for asset changes all in one terminal tab:
+
+```javascript
+  concurrent: {
+    target: {
+      tasks: ['nodemon', 'watch'],
+      logConcurrentOutput: true
+    }
+  }
+```
+*Note the output will be messy when combining certain tasks. This option is best used with tasks that don't exit like watch and nodemon to monitor the output of long-running concurrent tasks.*
 ## Contribute
 
 In lieu of a formal styleguide, take care to maintain the existing coding style.

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -4,11 +4,28 @@ var lpad = require('lpad');
 module.exports = function (grunt) {
 	grunt.registerMultiTask('concurrent', 'Run grunt tasks concurrently', function () {
 		var cb = this.async();
+		var options = this.options();
+		var opts;
+		var tasks;
+
+		// Optionally log the task output
+		if (options.logConcurrentOutput) {
+			opts = { stdio: 'inherit' };
+		}
+
+		// Set the tasks based on the config format
+		if (this.data.tasks) {
+			tasks = this.data.tasks;
+		} else {
+			tasks = this.data;
+		}
+
 		lpad.stdout('    ');
-		grunt.util.async.forEach(this.data, function (el, next) {
+		grunt.util.async.forEach(tasks, function (el, next) {
 			grunt.util.spawn({
 				grunt: true,
-				args: el
+				args: el,
+				opts: opts
 			}, function (err, result, code) {
 				if (err || code > 0) {
 					grunt.warn(result.stderr || result.stdout);


### PR DESCRIPTION
The [grunt.utils.spawn](http://gruntjs.com/api/grunt.util#grunt.util.spawn) function has an option for a child process to inherit the standard input and output of its parent process. By using this option, output from the child tasks will be logged in the terminal.

This is helpful for tasks like `watch` where you want to see what the task is doing.
