### PR TITLE
fixed typo in logConcurrentOutput example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,9 @@ grunt.initConfig({
 	concurrent: {
 		target: {
 			tasks: ['nodemon', 'watch'],
-			logConcurrentOutput: true
+			options: {
+				logConcurrentOutput: true
+			}
 		}
 	}
 });


### PR DESCRIPTION
There is a typo in the logConcurrentOutput example. I forgot to put the `logConcurrentOutput` in the options object.

It fixes issue #7.

My apologies.
