### PR TITLE
added test for logConcurrentOutput option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,7 @@ module.exports = function (grunt) {
 		concurrent: {
 			test: ['test1', 'test2', 'test3'],
 			log: {
-				tasks: ['simplemocha'],
+				tasks: ['nodemon', 'watch'],
 				options: {
 					logConcurrentOutput: true
 				}
@@ -12,17 +12,35 @@ module.exports = function (grunt) {
 		},
 		simplemocha: {
 			test: {
-				src: 'test/*.js'
+				src: 'test/*.js',
+				options: {
+					timeout: 6000
+				}
 			}
 		},
 		clean: {
 			test: ['test/tmp']
+		},
+		watch: {
+			scripts: {
+				files: ['tasks/*.js'],
+				tasks: ['default']
+			}
+		},
+		nodemon: {
+			dev: {
+				options: {
+					file: 'test/fixtures/server.js'
+				}
+			}
 		}
 	});
 
 	grunt.loadTasks('tasks');
 	grunt.loadNpmTasks('grunt-contrib-clean');
+	grunt.loadNpmTasks('grunt-contrib-watch');
 	grunt.loadNpmTasks('grunt-simple-mocha');
+	grunt.loadNpmTasks('grunt-nodemon');
 
 	grunt.registerTask('test1', function () {
 		console.log('test1');
@@ -45,7 +63,7 @@ module.exports = function (grunt) {
 
 	grunt.registerTask('default', [
 		'clean',
-		'concurrent',
+		'concurrent:test',
 		'simplemocha',
 		'clean'
 	]);

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-clean": "~0.4.0",
-    "grunt-simple-mocha": "~0.4.0"
+    "grunt-simple-mocha": "~0.4.0",
+    "grunt-contrib-watch": "~0.4.0",
+    "grunt-nodemon": "0.0.2"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"

--- a/test/fixtures/expectedLogOutput.txt
+++ b/test/fixtures/expectedLogOutput.txt
@@ -1,0 +1,3 @@
+Running "concurrent:log" (concurrent) task
+Running "nodemon:dev" (nodemon) task
+Running "watch" task

--- a/test/fixtures/server.js
+++ b/test/fixtures/server.js
@@ -1,0 +1,8 @@
+var net = require('net');
+
+var server = net.createServer(function (socket) {
+  socket.write('Echo server\r\n');
+  socket.pipe(socket);
+});
+
+server.listen(1337, '127.0.0.1');

--- a/test/test.js
+++ b/test/test.js
@@ -1,14 +1,40 @@
-/*global describe, it */
+/*global describe, it, before */
 'use strict';
 var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
-
+var spawn = require('child_process').spawn;
+var concurrentLogOuput = '';
 
 describe('concurrent', function () {
 	it('runs grunt tasks successfully', function () {
 		assert(fs.existsSync(path.join(__dirname, 'tmp/1')));
 		assert(fs.existsSync(path.join(__dirname, 'tmp/2')));
 		assert(fs.existsSync(path.join(__dirname, 'tmp/3')));
+	});
+});
+
+describe('When the \'logConcurrentOutput\' option is enabled, grunt-concurrent', function () {
+	before( function (done) {
+		var concurrentLogProcess = spawn('grunt', ['concurrent:log']);
+		var linesOfOutput = 0;
+		var doneLogging = false;
+
+		concurrentLogProcess.stdout.setEncoding('utf8');
+		concurrentLogProcess.stdout.on('data', function (data) {
+			concurrentLogOuput += data;
+			if ((data.indexOf('\n') !== -1)) {
+				linesOfOutput++;
+			}
+			if (linesOfOutput === 3 && !doneLogging) {
+				doneLogging = true;
+				concurrentLogProcess.kill();
+				done();
+			}
+		});
+	});
+
+	it('outputs concurrent logging', function () {
+		assert(concurrentLogOuput.indexOf(fs.readFileSync('test/fixtures/expectedLogOutput.txt', 'utf8') === 0));
 	});
 });


### PR DESCRIPTION
I did not commit a test when I added the `logConcurrentOutput` feature to grunt-concurrent.

I have since added a test which confirms that the concurrent tasks log output using the example config in the README.
