### PR TITLE
Warn user if limit is set to 1

### DIFF
--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -11,6 +11,11 @@ module.exports = function (grunt) {
 		});
 		// Set the tasks based on the config format
 		var tasks = this.data.tasks || this.data;
+		
+		// Warn the user if limit is 1, as this case is uncommon and not very useful
+		if (options.limit === 1) {
+			grunt.warn("limit is currently set to 1. Concurrent will probably not work as intended! Check your number of available CPUs.");
+		}
 
 		// Optionally log the task output
 		if (options.logConcurrentOutput) {


### PR DESCRIPTION
Concurrent is kind of pointless if limit is 1, as it will only ever run the first task, or one per time, at most. However, in VM's this is often the number of configured CPUs. Therefore, it is useful to warn users that their limit is misconfigured.
