### PR TITLE
fix interleaving of child stderr and stdout, print stdout when a child fails and has stderr

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,11 +4,14 @@ module.exports = function (grunt) {
 		concurrent: {
 			test: ['test1', 'test2', 'test3'],
 			testargs: ['testargs1', 'testargs2'],
-			log: {
+			testLogConcurrentOutput: {
 				options: {
 					logConcurrentOutput: true
 				},
 				tasks: ['nodemon', 'watch']
+			},
+			testOutputFail: {
+				tasks: ['testoutputfail']
 			}
 		},
 		simplemocha: {
@@ -71,6 +74,14 @@ module.exports = function (grunt) {
 		var args = grunt.option.flags().join();
 		grunt.file.write('test/tmp/args2', args);
 	});
+
+	grunt.registerTask('testoutputfail', function () {
+		console.log('console.log called');
+		console.error('console.error called');
+		grunt.log.writeln('grunt.log called');
+		grunt.warn('grunt.warn called');
+	});
+
 
 	grunt.registerTask('default', [
 		'clean',

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "dependencies": {
     "lpad": "~0.1.0",
-    "async": "~0.2.9"
+    "async": "~0.2.9",
+    "memorystream": "~0.2.0"
   },
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/test/test.js
+++ b/test/test.js
@@ -28,7 +28,7 @@ describe('concurrent', function () {
 		var logOutput = '';
 
 		before(function (done) {
-			var cp = spawn('grunt', ['concurrent:log']);
+			var cp = spawn('grunt', ['concurrent:testLogConcurrentOutput']);
 			var lines = 0;
 
 			cp.stdout.setEncoding('utf8');
@@ -48,8 +48,18 @@ describe('concurrent', function () {
 		});
 
 		it('outputs concurrent logging', function () {
-			var expected = 'Running "concurrent:log" (concurrent) task';
+			var expected = 'Running "concurrent:testLogConcurrentOutput" (concurrent) task';
 			assert(logOutput.indexOf(expected) !== -1);
+		});
+	});
+
+	it('child process has expected output on failure', function (done) {
+		exec('grunt concurrent:testOutputFail', function (error, stdout, stderr) {
+			assert(stdout.indexOf('console.log called') !== -1);
+			assert(stdout.indexOf('console.error called') !== -1);
+			assert(stdout.indexOf('grunt.log called') !== -1);
+			assert(stdout.indexOf('grunt.warn called') !== -1);
+			done();
 		});
 	});
 });


### PR DESCRIPTION
This improves the output of the task in the following ways:
- Make stdout and stderr from the child process correctly interleaved.
- Always print both stdout and stderr.  This is important for many tasks like grunt-contirb-compass that spawn a child and pipe through both stderr and stdout.
  - stderr is printed when a child process succeeds.  Previously only stdout was printed.
  - stdout is printed when a child process fils.  Previously only stderr was printed if there was stderr output.
## Testing
#### executed outside of concurrent

![screen shot 2013-12-01 at 9 34 17 am](https://f.cloud.github.com/assets/1527302/1650791/eb8abf7c-5aae-11e3-81fc-82867507ad60.png)
#### executed inside concurrent, before change

A task that has both stdout and stderr executed outside of concurrent
![screen shot 2013-12-01 at 9 42 34 am](https://f.cloud.github.com/assets/1527302/1650803/0dea65d0-5ab0-11e3-8349-148c326c43d3.png)
#### executed inside concurrent, after change

![screen shot 2013-12-01 at 9 23 33 am](https://f.cloud.github.com/assets/1527302/1650805/14c22aa0-5ab0-11e3-85a2-b1b65048ce33.png)
