### PR TITLE
Warn users about running more tasks than the concurrencyLimit

### DIFF
--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -13,6 +13,16 @@ module.exports = function (grunt) {
 		// Set the tasks based on the config format
 		var tasks = this.data.tasks || this.data;
 
+		// Warning if there are too many tasks to execute within the given limit
+		if (options.limit < tasks.length) {
+			grunt.log.oklns(
+				'Warning: There are more tasks than your concurrency limit. After ' +
+				'this limit is reached no further tasks will be run until the ' +
+				'current tasks are completed. You can adjust the limit in the ' + 
+				'concurrent task options'
+			);
+		}
+
 		// Optionally log the task output
 		if (options.logConcurrentOutput) {
 			spawnOptions = { stdio: 'inherit' };


### PR DESCRIPTION
Concurrent is often used with watch which will hold on to the processes spawned. If there are more tasks to be run than the concurrencyLimit and a task like watch never lets go of processes, concurrent will never execute some tasks. This is a particularly hard bug to track down when encountered since it will fail silently.
