### PR TITLE
grunt-concurrent-packagefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "async": "~0.2.9",
-    "pad-stdio": "^0.1.0"
+    "pad-stdio": "~0.1.0"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
incompatible version, cause error when use npm install
