### PR TITLE
Add option to set grunt path.

### DIFF
--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -8,7 +8,8 @@ module.exports = function (grunt) {
 		var spawnOptions;
 		var cb = this.async();
 		var options = this.options({
-			limit: Math.max(require('os').cpus().length, 2)
+			limit: Math.max(require('os').cpus().length, 2),
+			gruntPath: false
 		});
 		// Set the tasks based on the config format
 		var tasks = this.data.tasks || this.data;
@@ -30,11 +31,16 @@ module.exports = function (grunt) {
 
 		padStdio.stdout('    ');
 		async.eachLimit(tasks, options.limit, function (task, next) {
-			var cp = grunt.util.spawn({
-				grunt: true,
+			var taskOptions = {
 				args: [task].concat(grunt.option.flags()),
 				opts: spawnOptions
-			}, function (err, result, code) {
+			};
+			if (options.gruntPath) {
+				taskOptions.cmd = options.gruntPath;
+			} else {
+				taskOptions.grunt = true;
+			}
+			var cp = grunt.util.spawn(taskOptions, function (err, result, code) {
 				if (err || code > 0) {
 					grunt.warn(result.stderr || result.stdout);
 				}


### PR DESCRIPTION
grunt is spawned using `grunt.util.spawn({grunt: true})`, which
is fine for almost all use cases. However, when running 
Grunt programatically, let's say you have `run.js` with 

```
require('grunt').tasks()
```

and try to run

```
node run.js
```

`grunt.util.spawn({grunt: true})` will spawn `node run.js` instead of `grunt`.
I suppose it uses argv to choose the command to run.

I am aware that this is rather an issue of grunt than one of this package,
but this little workaround should not do any harm 
(if the option is not set, the behavior will not change), and could
be useful for such a use case.
