### PR TITLE
disabling inheriting of process.stdin as it would trump ownership of std...

### DIFF
--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -26,7 +26,7 @@ module.exports = function (grunt) {
 
 		// Optionally log the task output
 		if (options.logConcurrentOutput) {
-			spawnOptions = { stdio: 'inherit' };
+		    spawnOptions = { stdio: ['ignore', process.stdout, process.stderr] };
 		}
 
 		padStdio.stdout('    ');


### PR DESCRIPTION
## Issue summary

I have a project that runs nodemon and watch through grunt-concurrent (a very common setup, apparently). I would intermittently run into an issue in which after CMD-C'ing (SIGINT) out of grunt-concurrent in order to regain control of my terminal, it would not display any input at all, subsequently rendering that terminal session useless. I would then have to open a new one and start working from it. I'm surprised that looking up on the internet I couldn't find more people with this issue. Check the images below for a better description of the problem:

First I run grunt server, which is my grunt-concurrent task that fires watch and nodemon:
![screen shot 2015-02-17 at 7 58 41 pm](https://cloud.githubusercontent.com/assets/1004225/6238131/d5a45838-b6df-11e4-8c23-8f24935e7e5a.png)

To quit it, I have to hit CMD-C three times (I presume once for each concurrent task and one for grunt-concurrent itself). Only the last one appears as ^C:
![screen shot 2015-02-17 at 7 59 02 pm](https://cloud.githubusercontent.com/assets/1004225/6238176/1dfce96a-b6e0-11e4-8409-b23978301ffd.png)

After that, anything I type is not displayed in the terminal window, but it is received by the bash process, so you can see that after I hit enter, I get an "asdfasdfasdf: command not found" message.
![screen shot 2015-02-17 at 7 59 45 pm](https://cloud.githubusercontent.com/assets/1004225/6238261/bd1a3912-b6e0-11e4-83d1-b7242d54d6c5.png)

If I run "grunt server" again from this state, the concurrent task starts again, but this time I can hit CMD-C, or whatever key combination i'd like and there is absolutely no way of getting out of this state except for terminating the whole shell.
![screen shot 2015-02-17 at 8 00 20 pm](https://cloud.githubusercontent.com/assets/1004225/6238282/e6cbd8ec-b6e0-11e4-89c3-24a1513767d6.png)

## Setup where issue is reproducible

**OS**: OSX Yosemite 10.10.1 
**Shell**: /bin/bash (GNU bash, version 3.2.53(1)-release (x86_64-apple-darwin14))
**Node**: v0.10.26
**Grunt CLI**: v0.1.13
**Grunt**: v0.4.5

**Grunt config**:
```javascript
        nodemon: {
            dev: {
                script: 'server.js',
                options: {
                    args: [],
                    ignore: ['public/**'],
                    ext: 'js,html',
                    env: {
                        PORT: 3000
                    },
                    cwd: __dirname
                }
            }
        },
        concurrent: {
            tasks: ['nodemon', 'watch'],
            options: {
                logConcurrentOutput: true
            }
        },
        watch: {
            js: {
                files: ['app/**/*.js', 'public/js/**'],
                tasks: ['jshint'],
                options: {
                    livereload: liveReloadConfig
                }
            },
            html: {
                files: ['public/views/**', 'app/views/**'],
                options: {
                    livereload: liveReloadConfig
                }
            },
            css: {
                files: ['public/css/**'],
                options: {
                    livereload: liveReloadConfig
                }
            },
            sass: {
                files: ['public/sass/**/*.scss'],
                tasks: ['sass'],
                options: {
                    livereload: liveReloadConfig
                }
            }
        },
```
**Grunt task**:
```javascript
    grunt.registerTask('server', ['uglify', 'sass', 'concurrent']);
```

## Proposed solution

I tested running nodemon and watch independently and CMD-C out of them, and had no issues. It really seem to stem out from the usage of grunt-concurrent. Disabling the "logConcurrentOutput" flag would cause the issue not to happen, so I figured it could be related to this. Looking into grunt-concurrent sources and at node's documentation here (http://nodejs.org/api/child_process.html#child_process_options_stdio) I figured it could be the case that the spawned processes were taking over ownership of the inherited stdin, and when exiting the concurrent task, my terminal would have lost ownership of the input stream.

Changing this so that the child processes would only inherit stdout and stderr would still log messages from the child processes back to the current terminal session, but it would prevent dispute over stdin.

This might break cases in which people are using grunt-concurrent for running tasks that can be interacted with from the terminal, but i'm not sure if this works with the current code too.

## Test cases

Tests are still passing. Stdin redirection wasn't tested before so it seems not to be crucial to the goal of grunt-concurrent, so I'm leaving the existing test as it is.

## Considerations

Not sure if this is the correct way to go, but I'd like to send the pull request to get some discussion around this started. Have you guys ever run into this issue? Do you have any suggestions of what else should I look into? Is this patch helpful, would you like me to modify it in any means before it's a candidate to be merged?

Thanks in advance for your attention and patience with my huge wall of text and struggle with english grammar as it's not my native language :P