### PR TITLE
Allow to turn off padding in order to avoid overwriting `process.stdout.write`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,13 @@ Default: Twice the number of CPU cores with a minimum of 2
 
 Limit how many tasks that are run concurrently.
 
+### padOutput
+
+Type: `boolean`
+Default: `true`
+
+Pad the task output with 4 spaces to visually distinguish the concurrent tasks.
+
 ### logConcurrentOutput
 
 Type: `boolean`  

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -29,7 +29,11 @@ module.exports = function (grunt) {
 			spawnOptions = { stdio: 'inherit' };
 		}
 
-		padStdio.stdout('    ');
+		// Pad task output
+		if (options.padOutput !== false) {
+			padStdio.stdout('    ');
+		}
+
 		async.eachLimit(tasks, options.limit, function (task, next) {
 			var cp = grunt.util.spawn({
 				grunt: true,
@@ -45,7 +49,9 @@ module.exports = function (grunt) {
 
 			cpCache.push(cp);
 		}, function () {
-			padStdio.stdout();
+			if (options.padOutput !== false) {
+				padStdio.stdout();
+			}
 			cb();
 		});
 	});


### PR DESCRIPTION
I'm using `grunt-concurrent` in conjunction with [`logfile-grunt`](https://github.com/brutaldev/logfile-grunt), which allows to capture the output of a Grunt task to a log file.

The problem I'm running into is that once `grunt-concurrent` task starts executing all output gets lost.

`logflie-grunt` works by hooking into `process.stdout.write` ([here](https://github.com/brutaldev/logfile-grunt/blob/master/logfile-grunt.js#L49-L51)).
Whereas `grunt-concurrent` uses `pad-stdio` which overwrites `process.stdout.write` ([here] (https://github.com/sindresorhus/pad-stdio/blob/master/index.js#L7))

This PR introduces a new option - `padOutput` (on by default) which allows to disable padding to avoid the conflict. (It doesn't work on Windows anyway: #55.)

Original discussion here: brutaldev/logfile-grunt#3