### PR TITLE
Override flags

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,24 @@ Default: Twice the number of CPU cores with a minimum of 2
 
 Limit how many tasks that are run concurrently.
 
+### flags
+
+Type: `Object`  
+Default: `{}`
+
+Merge & overrides task flags.
+
+```js
+target: {
+	tasks: ['nodemon', 'watch'],
+	options: {
+		flags: {
+			foo: 'value'
+		}
+	}
+}
+```
+
 ### logConcurrentOutput
 
 Type: `boolean`  

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -12,6 +12,9 @@ module.exports = function (grunt) {
 		});
 		var tasks = this.data.tasks || this.data;
 		var flags = grunt.option.flags();
+		var newFlags = Object.keys(opts.flags || {}).map(function(key){
+			return '--' + key + '=' + opts.flags[key];
+		});
 
 		if (opts.limit < tasks.length) {
 			grunt.log.oklns(
@@ -27,7 +30,7 @@ module.exports = function (grunt) {
 		async.eachLimit(tasks, opts.limit, function (task, next) {
 			var cp = grunt.util.spawn({
 				grunt: true,
-				args: [task].concat(flags),
+				args: [task].concat(flags).concat(newFlags),
 				opts: {
 					stdio: ['ignore', 'pipe', 'pipe']
 				}


### PR DESCRIPTION
Hi, here is my contribution.
In some cases I had to spawn the concurrent tasks with a different values or new flags, so I've added a new option `flags`.

This option allows to override the CLI args of concurrent tasks.