### PR TITLE
Swap pad-stdio dep for pad-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "async": "^1.2.1",
-    "pad-stdio": "^2.0.0"
+    "pad-stream": "^1.0.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -1,6 +1,6 @@
 'use strict';
 var os = require('os');
-var padStdio = require('pad-stdio');
+var padStream = require('pad-stream');
 var async = require('async');
 var cpCache = [];
 
@@ -22,8 +22,6 @@ module.exports = function (grunt) {
 			);
 		}
 
-		padStdio.stdout('    ');
-
 		async.eachLimit(tasks, opts.limit, function (task, next) {
 			var cp = grunt.util.spawn({
 				grunt: true,
@@ -40,8 +38,8 @@ module.exports = function (grunt) {
 			});
 
 			if (opts.logConcurrentOutput) {
-				cp.stdout.pipe(process.stdout);
-				cp.stderr.pipe(process.stderr);
+				cp.stdout.pipe(padStream(' ', 4)).pipe(process.stdout);
+				cp.stderr.pipe(padStream(' ', 4)).pipe(process.stderr);
 			}
 
 			cpCache.push(cp);
@@ -50,7 +48,6 @@ module.exports = function (grunt) {
 				grunt.warn(err);
 			}
 
-			padStdio.stdout();
 			cb();
 		});
 	});


### PR DESCRIPTION
Swap pad-stdio dependency for pad-stream, which has better handling for padding insertion with newlines.

Fixes https://github.com/sindresorhus/grunt-concurrent/issues/66

__Note:__ This doesn't handle the `logConcurrentOutput: false` case correctly, in that no padding will currently be applied. I started down the path of using a `stream.Readable` to pipe the result stdout/stderr to pad-stream and then convert that back to a string, but I didn't quite get it working, and it just felt like something that you might have a better approach for anyway. Looking forward to your feedback!