### PR TITLE
Clean up child processes on SIGINT (CTRL-C)

### DIFF
--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -54,9 +54,12 @@ module.exports = function (grunt) {
 	});
 };
 
-// make sure all child processes are killed when grunt exits
-process.on('exit', function () {
+function cleanup () {
 	cpCache.forEach(function (el) {
 		el.kill('SIGKILL');
 	});
-});
+}
+
+// make sure all child processes are killed when grunt exits
+process.on('exit', cleanup);
+process.on('SIGINT', cleanup);


### PR DESCRIPTION
The current behavior when we CTRL-C seems to be that the 'exit' event is not dispatched on the parent process until all spawned processes exit, resulting in orphaned processes when a spawned process doesn't handle SIGINT correctly. Cleaning up child processes on SIGINT handles this scenario.