### PR TITLE
New option "cwd" allows for setting the current working directory

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,12 @@ grunt.registerTask('default', ['concurrent:target']);
 
 *The output will be messy when combining certain tasks. This option is best used with tasks that don't exit like `watch` and `nodemon` to monitor the output of long-running concurrent tasks.*
 
+### cwd
+
+Type: `string`
+Default: Current working directory of grunt process
+
+Set current working directory of the child processes.
 
 ## License
 

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -28,6 +28,7 @@ module.exports = function (grunt) {
 				grunt: true,
 				args: [task].concat(flags),
 				opts: {
+					cwd: opts.cwd,
 					stdio: ['ignore', 'pipe', 'pipe']
 				}
 			}, function (err, result) {


### PR DESCRIPTION
Useful when the working directory was changed in Gruntfile prior to spawning child processes.