### PR TITLE
Fix concurrent output logs not being colorized

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -77,7 +77,7 @@ module.exports = function (grunt) {
 
 	grunt.registerTask('colorcheck', function () {
 		// writes 'true' or 'false' to the file
-		var supports = '' + !!supportsColor;
+		var supports = String(Boolean(supportsColor));
 		grunt.file.write('test/tmp/colors', supports);
 	});
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,6 @@
 'use strict';
+var supportsColor = require('supports-color');
+
 module.exports = function (grunt) {
 	grunt.initConfig({
 		concurrent: {
@@ -9,7 +11,8 @@ module.exports = function (grunt) {
 					logConcurrentOutput: true
 				},
 				tasks: ['nodemon', 'watch']
-			}
+			},
+			colors: ['colorcheck']
 		},
 		simplemocha: {
 			test: {
@@ -70,6 +73,12 @@ module.exports = function (grunt) {
 	grunt.registerTask('testargs2', function () {
 		var args = grunt.option.flags().join();
 		grunt.file.write('test/tmp/args2', args);
+	});
+
+	grunt.registerTask('colorcheck', function () {
+		// writes 'true' or 'false' to the file
+		var supports = '' + !!supportsColor;
+		grunt.file.write('test/tmp/colors', supports);
 	});
 
 	grunt.registerTask('default', [

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "grunt-simple-mocha": "^0.4.0",
     "nodemon": "^1.2.1",
     "path-exists": "^1.0.0",
+    "supports-color": "^3.1.2",
     "xo": "*"
   },
   "engines": {

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -14,6 +14,14 @@ module.exports = function (grunt) {
 		var tasks = this.data.tasks || this.data;
 		var flags = grunt.option.flags();
 
+		if (flags.indexOf('--no-color') === -1 &&
+			flags.indexOf('--no-colors') === -1 &&
+			flags.indexOf('--color=false') === -1) {
+			// append the flag so that support-colors won't return false
+			// see issue #70 for details
+			flags.push('--color');
+		}
+
 		if (opts.limit < tasks.length) {
 			grunt.log.oklns(
 				'Warning: There are more tasks than your concurrency limit. After ' +

--- a/test/test.js
+++ b/test/test.js
@@ -17,8 +17,10 @@ describe('concurrent', function () {
 		var expected = '--arg1=test,--arg2';
 
 		exec('grunt concurrent:testargs ' + expected, function () {
-			assert.equal(fs.readFileSync(path.join(__dirname, 'tmp/args1'), 'utf8'), expected);
-			assert.equal(fs.readFileSync(path.join(__dirname, 'tmp/args2'), 'utf8'), expected);
+			var args1 = fs.readFileSync(path.join(__dirname, 'tmp/args1'), 'utf8');
+			var args2 = fs.readFileSync(path.join(__dirname, 'tmp/args2'), 'utf8');
+			assert.ok(args1.indexOf(expected) !== -1);
+			assert.ok(args2.indexOf(expected) !== -1);
 			done();
 		});
 	});
@@ -27,19 +29,39 @@ describe('concurrent', function () {
 		var logOutput = '';
 
 		before(function (done) {
+			var doneCalled = false;
 			var cp = spawn('grunt', ['concurrent:log']);
 
 			cp.stdout.setEncoding('utf8');
 			cp.stdout.on('data', function (data) {
 				logOutput += data;
 				cp.kill();
-				done();
+				if (!doneCalled) {
+					doneCalled = true;
+					done();
+				}
 			});
 		});
 
 		it('outputs concurrent logging', function () {
 			var expected = 'Running "concurrent:log" (concurrent) task';
 			assert(logOutput.indexOf(expected) !== -1);
+		});
+	});
+
+	describe('works with supports-color lib', function () {
+		it('ensures that colors are supported by default', function (done) {
+			exec('grunt concurrent:colors', function () {
+				assert.equal(fs.readFileSync(path.join(__dirname, 'tmp/colors'), 'utf8'), 'true');
+				done();
+			});
+		});
+
+		it('doesn\'t support colors with --no-color option', function (done) {
+			exec('grunt concurrent:colors --no-color', function () {
+				assert.equal(fs.readFileSync(path.join(__dirname, 'tmp/colors'), 'utf8'), 'false');
+				done();
+			});
 		});
 	});
 });


### PR DESCRIPTION
Also:
- changed the first test so that it will work with the `--color` flag added
- fixed a hidden bug in the second test - `done` was called multiple times because the grunt process wasn't killed immediately

-

Fixes #70.