### PR TITLE
`arrify` is a run-time dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
     "tasks"
   ],
   "dependencies": {
+    "arrify": "^1.0.1",
     "async": "^1.2.1",
     "indent-string": "^2.0.0",
     "pad-stream": "^1.0.0"
   },
   "devDependencies": {
-    "arrify": "^1.0.1",
     "cross-spawn": "^2.0.0",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",


### PR DESCRIPTION
2.2.0 broke our CI chains because the `arrify` module is not installed.