### PR TITLE
Add ability to config indentation

### DIFF
--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -10,7 +10,8 @@ module.exports = function (grunt) {
 	grunt.registerMultiTask('concurrent', 'Run grunt tasks concurrently', function () {
 		var cb = this.async();
 		var opts = this.options({
-			limit: Math.max((os.cpus().length || 1) * 2, 2)
+			limit: Math.max((os.cpus().length || 1) * 2, 2),
+			indent: 4
 		});
 		var tasks = this.data.tasks || this.data;
 		var flags = grunt.option.flags();
@@ -41,15 +42,15 @@ module.exports = function (grunt) {
 				}
 			}, function (err, result) {
 				if (!opts.logConcurrentOutput) {
-					grunt.log.writeln('\n' + indentString(result.stdout + result.stderr, ' ', 4));
+					grunt.log.writeln('\n' + indentString(result.stdout + result.stderr, ' ', opts.indent));
 				}
 
 				next(err);
 			});
 
 			if (opts.logConcurrentOutput) {
-				cp.stdout.pipe(padStream(' ', 4)).pipe(process.stdout);
-				cp.stderr.pipe(padStream(' ', 4)).pipe(process.stderr);
+				cp.stdout.pipe(padStream(' ', opts.indent)).pipe(process.stdout);
+				cp.stderr.pipe(padStream(' ', opts.indent)).pipe(process.stderr);
 			}
 
 			cpCache.push(cp);


### PR DESCRIPTION
This fixes issue https://github.com/sindresorhus/grunt-concurrent/issues/62

Bunyan doesn't work right when the output is indented. By allowing a user to configure the indent themselves (to 0), they can then pipe the output to bunyan and see bunyan logs formatted correctly. For instance, I often do `grunt serve | bunyan`

This doesn't change default behavior.