### PR TITLE
Add option to prepend each line of the output with the taske name

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "arrify": "^1.0.1",
     "async": "^1.2.1",
+    "colors": "^1.1.2",
     "indent-string": "^2.0.0",
     "pad-stream": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "arrify": "^1.0.1",
     "async": "^1.2.1",
-    "colors": "^1.1.2",
+    "chalk": "^2.0.1",
     "indent-string": "^2.0.0",
     "pad-stream": "^1.0.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,12 @@ grunt.registerTask('default', ['concurrent:target']);
 
 *The output will be messy when combining certain tasks. This option is best used with tasks that don't exit like `watch` and `nodemon` to monitor the output of long-running concurrent tasks.*
 
+### logTaskName
+
+Type: `boolean|number`<br>
+Default: `false`
+
+When logging the output of concurrent tasks with `logConcurrentOutput` you can set `logTaskName` to prepend the name of the task to the beginning of every output line. Specify a number to limit the maximum number of characters used for the task name.
 
 ## License
 

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -58,7 +58,7 @@ module.exports = function (grunt) {
 					var colorFn = colors.length > 0 ? chalk[colors.shift()] : function(s) { return s };//use an available color or none if more tasks then colors available
 					var maxLength = typeof opts.logTaskName === 'number' ?  opts.logTaskName : Math.min(maxTaskLength,12);//task labels in output up to 12 characters
 					var numSpaces = (task.length > maxLength ? 0 : maxLength-task.length) + 3;//let output from all tasks be aligned
-                    padString = '['+colorFn(task.slice(0,maxLength))+']'+(' '.repeat(numSpaces));
+					padString = '['+colorFn(task.slice(0,maxLength))+']'+(' '.repeat(numSpaces));
 				} else {
 					padString = '    ';
 				}

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -4,11 +4,11 @@ var padStream = require('pad-stream');
 var async = require('async');
 var arrify = require('arrify');
 var indentString = require('indent-string');
-var colors = require('colors');
+var chalk = require('chalk');
 
 var cpCache = [];
 
-var colorsAvailable = ["blue","magenta","yellow","green","red","cyan","white","gray"];
+var colors = ["blue","magenta","yellow","green","red","cyan","white","gray","redBright","greenBright","yellowBright","blueBright","magentaBright","cyanBright"];
 
 module.exports = function (grunt) {
 	grunt.registerMultiTask('concurrent', 'Run grunt tasks concurrently', function () {
@@ -53,21 +53,18 @@ module.exports = function (grunt) {
 			});
 
 			if (opts.logConcurrentOutput) {
-				var taskLabel,numSpaces;
-				if(opts.logTaskName)
-				{
-					var colorFn = colorsAvailable.length > 0 ? colors[colorsAvailable.shift()] : function(s) { return s };//use an available color or none if more tasks then colors available
+				var padString;
+				if (opts.logTaskName) {
+					var colorFn = colors.length > 0 ? chalk[colors.shift()] : function(s) { return s };//use an available color or none if more tasks then colors available
 					var maxLength = typeof opts.logTaskName === 'number' ?  opts.logTaskName : Math.min(maxTaskLength,12);//task labels in output up to 12 characters
-					taskLabel = '['+colorFn(task.substr(0,maxLength))+']';
-					numSpaces = (task.length > maxLength ? 0 : maxLength-task.length) + 3;//let output from all tasks be aligned
+					var numSpaces = (task.length > maxLength ? 0 : maxLength-task.length) + 3;//let output from all tasks be aligned
+                    padString = '['+colorFn(task.slice(0,maxLength))+']'+(' '.repeat(numSpaces));
+				} else {
+					padString = '    ';
 				}
-				else
-				{
-					taskLabel = '';
-					numSpaces = 4;
-				}
-				cp.stdout.pipe(padStream(' ', numSpaces)).pipe(padStream(taskLabel, 1)).pipe(process.stdout);
-				cp.stderr.pipe(padStream(' ', numSpaces)).pipe(padStream(taskLabel, 1)).pipe(process.stderr);
+
+				cp.stdout.pipe(padStream(padString, 1)).pipe(process.stdout);
+				cp.stderr.pipe(padStream(padString, 1)).pipe(process.stderr);
 			}
 
 			cpCache.push(cp);

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -53,19 +53,19 @@ module.exports = function (grunt) {
 			});
 
 			if (opts.logConcurrentOutput) {
-                var taskLabel,numSpaces;
-			    if(opts.logTaskName)
-                {
-                    var colorFn = colorsAvailable.length > 0 ? colors[colorsAvailable.shift()] : function(s) { return s };//use an available color or none if more tasks then colors available
-                    var maxLength = typeof opts.logTaskName === 'number' ?  opts.logTaskName : Math.min(maxTaskLength,12);//task labels in output up to 12 characters
-                    taskLabel = '['+colorFn(task.substr(0,maxLength))+']';
-                    numSpaces = (task.length > maxLength ? 0 : maxLength-task.length) + 3;//let output from all tasks be aligned
-                }
-                else
-                {
-                    taskLabel = '';
-                    numSpaces = 4;
-                }
+				var taskLabel,numSpaces;
+				if(opts.logTaskName)
+				{
+					var colorFn = colorsAvailable.length > 0 ? colors[colorsAvailable.shift()] : function(s) { return s };//use an available color or none if more tasks then colors available
+					var maxLength = typeof opts.logTaskName === 'number' ?  opts.logTaskName : Math.min(maxTaskLength,12);//task labels in output up to 12 characters
+					taskLabel = '['+colorFn(task.substr(0,maxLength))+']';
+					numSpaces = (task.length > maxLength ? 0 : maxLength-task.length) + 3;//let output from all tasks be aligned
+				}
+				else
+				{
+					taskLabel = '';
+					numSpaces = 4;
+				}
 				cp.stdout.pipe(padStream(' ', numSpaces)).pipe(padStream(taskLabel, 1)).pipe(process.stdout);
 				cp.stderr.pipe(padStream(' ', numSpaces)).pipe(padStream(taskLabel, 1)).pipe(process.stderr);
 			}

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -8,8 +8,6 @@ var chalk = require('chalk');
 
 var cpCache = [];
 
-var colors = ["blue","magenta","yellow","green","red","cyan","white","gray","redBright","greenBright","yellowBright","blueBright","magentaBright","cyanBright"];
-
 module.exports = function (grunt) {
 	grunt.registerMultiTask('concurrent', 'Run grunt tasks concurrently', function () {
 		var cb = this.async();
@@ -18,6 +16,7 @@ module.exports = function (grunt) {
 		});
 		var tasks = this.data.tasks || this.data;
 		var maxTaskLength = Math.max.apply(null,(tasks.map(function(task){ return task.length})));
+		var colors = ["blue","magenta","yellow","green","red","cyan","white","gray"];
 		var flags = grunt.option.flags();
 
 		if (flags.indexOf('--no-color') === -1 &&
@@ -56,7 +55,7 @@ module.exports = function (grunt) {
 				var padString;
 				if (opts.logTaskName) {
 					var colorFn = colors.length > 0 ? chalk[colors.shift()] : function(s) { return s };//use an available color or none if more tasks then colors available
-					var maxLength = typeof opts.logTaskName === 'number' ?  opts.logTaskName : Math.min(maxTaskLength,12);//task labels in output up to 12 characters
+					var maxLength = typeof opts.logTaskName === 'number' ?  opts.logTaskName : maxTaskLength;//use the longest task name as maximum, or the maximum provided by logTaskName
 					var numSpaces = (task.length > maxLength ? 0 : maxLength-task.length) + 3;//let output from all tasks be aligned
 					padString = '['+colorFn(task.slice(0,maxLength))+']'+(' '.repeat(numSpaces));
 				} else {


### PR DESCRIPTION
adds support for a new config option `logTaskName`.
When set to true and used together with `logConcurrentOutput` it will prepend the taskname in a task specific color to each line of output with a default maximum of 12 chars.
When logTaskName is a number, it will be used as the maximum number of chars to be used for the taskname.

In the example below, the concurrent tasks "**web**pack:dev" and "**exe**c:dev" are prepended with their name and their own color with logTaskName=3 (max 3 chars)
![image](https://user-images.githubusercontent.com/341567/28431330-4eb208bc-6d84-11e7-9474-1e3555c02561.png)
