### PR TITLE
Allow `tasks` to be function that returns task list

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -7,6 +7,14 @@ module.exports = function (grunt) {
 			test: ['test1', 'test2', 'test3'],
 			testSequence: ['test4', ['test5', 'test6']],
 			testargs: ['testargs1', 'testargs2'],
+			testfn: function(target){
+				return ['testfn1:'+target];
+			},
+			testfnTasks: {
+				tasks: function(target){
+					return ['testfn2:'+target];
+				}
+			},
 			log: {
 				options: {
 					logConcurrentOutput: true
@@ -90,6 +98,14 @@ module.exports = function (grunt) {
 	grunt.registerTask('testargs2', function () {
 		var args = grunt.option.flags().join();
 		grunt.file.write('test/tmp/args2', args);
+	});
+
+	grunt.registerTask('testfn1', function (target) {
+		grunt.file.write('test/tmp/fn1', target);
+	});
+
+	grunt.registerTask('testfn2', function (target) {
+		grunt.file.write('test/tmp/fn2', target);
 	});
 
 	grunt.registerTask('colorcheck', function () {

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,36 @@ grunt.initConfig({
 ```
 Now `jshint` will always be done before `coffee` and `sass` runs independent of both of them.
 
+## Pass task arguments
+
+```js
+grunt.initConfig({
+	concurrent: {
+		target: function(env){
+			return [
+				'build:'+env
+			];
+		},
+		target2: {
+			tasks: function(env){
+				return [
+					'build'+env
+				];
+			}
+		}
+	}
+});
+```
+You can pass
+
+```
+$ grunt concurrent:target:dev
+# Run will run `build:dev` as part of a concurrent task
+
+$ grunt concurrent:target2:prod
+# Run will run `build:prod` as part of a concurrent task
+```
+
 
 ## Options
 

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -13,9 +13,13 @@ module.exports = function (grunt) {
 		var opts = this.options({
 			limit: Math.max((os.cpus().length || 1) * 2, 2)
 		});
+		
 		var tasks = this.data.tasks || this.data;
+		if (tasks instanceof Function){
+			tasks = tasks.apply(null, arguments);
+		}
+		
 		var flags = grunt.option.flags();
-
 		if (flags.indexOf('--no-color') === -1 &&
 			flags.indexOf('--no-colors') === -1 &&
 			flags.indexOf('--color=false') === -1) {

--- a/test/test.js
+++ b/test/test.js
@@ -31,6 +31,16 @@ describe('concurrent', function () {
 			done();
 		});
 	});
+	
+	it('passes arguments to tasks', function(done){
+		exec('grunt concurrent:testfn:dev concurrent:testfnTasks:prod', function () {
+			var fn1 = fs.readFileSync(path.join(__dirname, 'tmp/fn1'), 'utf8');
+			var fn2 = fs.readFileSync(path.join(__dirname, 'tmp/fn2'), 'utf8');
+			assert.ok(fn1.indexOf('dev') !== -1);
+			assert.ok(fn2.indexOf('prod') !== -1);
+			done();
+		});
+	});
 
 	describe('`logConcurrentOutput` option', function () {
 		var logOutput = '';


### PR DESCRIPTION
I ran into a situation where I needed to customise the task list and pass additional data to the tasks I was running.

This is a small change that allows the tasks to be configured as a function that returns the list of tasks to be run. This gives more flexibility to customise the task list or pass arguments to the tasks.

e.g.
```javascript
grunt.initConfig({
	concurrent: {
		// `target: (arg) => ['task:'+arg]`
		serve: function(env){
			// Can now customise the task list or forward arguments on to tasks
			return [
				'watch1:'+env
			];
		}

		// or with `tasks` property

		// `target: {tasks: (arg) => ['task:'+arg]}`
		watch: {
			tasks: function(env){
				return [
					'watch1:'+env
				];
			}
		}
	}
});
```
```
$ grunt concurrent:serve:dev
$ grunt concurrent:watch:prod
```

I've added a test and updated the readme (hopefully it's clear enough!)