### PR TITLE
Feature request: Allow passing through spawn opts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,32 @@ grunt.registerTask('default', ['concurrent:target']);
 
 *The output will be messy when combining certain tasks. This option is best used with tasks that don't exit like `watch` and `nodemon` to monitor the output of long-running concurrent tasks.*
 
+### spawn
+
+Type: `object`<br>
+Default: Set stdio to ignore stdin and pipe stdout and stderr
+
+This option allows you to set the `opts` parameter passed to
+[`grunt.util.spawn`](https://gruntjs.com/api/grunt.util#grunt.util.spawn). By
+default, the configuration is equivalent to:
+
+```js
+grunt.initConfig({
+	concurrent: {
+		target: {
+			options: {
+				spawn: {
+					stdio: ['ignore', 'pipe', 'pipe']
+				}
+			}
+		}
+	}
+});
+```
+
+This is nice if you'd like to have a little more control over how the target
+actually spawns. Note that the options are originally defined for node's
+[`child_process.spawn`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).
 
 ## License
 

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -11,7 +11,8 @@ module.exports = function (grunt) {
 	grunt.registerMultiTask('concurrent', 'Run grunt tasks concurrently', function () {
 		var cb = this.async();
 		var opts = this.options({
-			limit: Math.max((os.cpus().length || 1) * 2, 2)
+			limit: Math.max((os.cpus().length || 1) * 2, 2),
+			spawn: {stdio: ['ignore', 'pipe', 'pipe']},
 		});
 		var tasks = this.data.tasks || this.data;
 		var flags = grunt.option.flags();
@@ -37,9 +38,7 @@ module.exports = function (grunt) {
 			var cp = grunt.util.spawn({
 				grunt: true,
 				args: arrify(task).concat(flags),
-				opts: {
-					stdio: ['ignore', 'pipe', 'pipe']
-				}
+				opts: opts.spawn
 			}, function (err, result) {
 				if (!opts.logConcurrentOutput) {
 					grunt.log.writeln('\n' + indentString(result.stdout + result.stderr, ' ', 4));


### PR DESCRIPTION
There is currently no way without hacking to pass through `opts` to `grunt.util.spawn` (and then to `child_process.spawn`). This PR adds a `spawn` key to the task options which allows custom definition of those `opts`, defaulting to the original stdio configuration.