### PR TITLE
Add omitLogIndentation option and lock xo version

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -13,7 +13,20 @@ module.exports = function (grunt) {
 				},
 				tasks: ['nodemon', 'watch']
 			},
-			colors: ['colorcheck']
+			colors: ['colorcheck'],
+			omitLogIndentationTrue: {
+				options: {
+					omitLogIndentation: true
+				},
+				tasks: ['testOmitLogIndentation']
+			},
+			omitLogIndentationFalse: {
+				options: {
+					omitLogIndentation: false
+				},
+				tasks: ['testOmitLogIndentation']
+			},
+			omitLogIndentationDefault: ['testOmitLogIndentation']
 		},
 		simplemocha: {
 			test: {
@@ -96,6 +109,10 @@ module.exports = function (grunt) {
 		// writes 'true' or 'false' to the file
 		var supports = String(Boolean(supportsColor));
 		grunt.file.write('test/tmp/colors', supports);
+	});
+
+	grunt.registerTask('testOmitLogIndentation', function () {
+		console.log('omitLogIndentation test output');
 	});
 
 	grunt.registerTask('default', [

--- a/package.json
+++ b/package.json
@@ -42,9 +42,10 @@
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.7.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-nodemon": "^0.4.0",
+    "grunt-nodemon": "0.4.0",
     "grunt-simple-mocha": "^0.4.0",
-    "nodemon": "^1.2.1",
+    "mocha": "^2.5.3",
+    "nodemon": "~1.3.8",
     "path-exists": "^2.0.0",
     "supports-color": "^3.1.2",
     "xo": "^0.16.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "nodemon": "^1.2.1",
     "path-exists": "^2.0.0",
     "supports-color": "^3.1.2",
-    "xo": "*"
+    "xo": "^0.17.1"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "nodemon": "^1.2.1",
     "path-exists": "^2.0.0",
     "supports-color": "^3.1.2",
-    "xo": "^0.17.1"
+    "xo": "^0.16.0"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,13 @@ grunt.registerTask('default', ['concurrent:target']);
 
 *The output will be messy when combining certain tasks. This option is best used with tasks that don't exit like `watch` and `nodemon` to monitor the output of long-running concurrent tasks.*
 
+### omitLogIndentation
+
+Type: `boolean`<br>
+Default: `false`
+
+You can optionally omit the indentation in the log output of your concurrent tasks by specifying the `omitLogIndentation` option. This can be useful for running tasks in parallel for a stdout parser which expect no indentation, e.g. TeamCity tests.
+
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ grunt.registerTask('default', ['concurrent:target']);
 Type: `boolean`<br>
 Default: `false`
 
-You can optionally omit the indentation in the log output of your concurrent tasks by specifying the `omitLogIndentation` option. This can be useful for running tasks in parallel for a stdout parser which expect no indentation, e.g. TeamCity tests.
+You can optionally omit the indentation in the log output of your concurrent tasks by specifying the `omitLogIndentation` option. This can be useful for running tasks in parallel for a stdout parser which expects no indentation, e.g. TeamCity tests.
 
 
 ## License

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -42,15 +42,25 @@ module.exports = function (grunt) {
 				}
 			}, function (err, result) {
 				if (!opts.logConcurrentOutput) {
-					grunt.log.writeln('\n' + indentString(result.stdout + result.stderr, ' ', 4));
+					var output = result.stdout + result.stderr;
+					if (!opts.omitLogIndentation) {
+						output = indentString(output, ' ', 4);
+					}
+					grunt.log.writeln('\n' + output);
 				}
 
 				next(err);
 			});
 
 			if (opts.logConcurrentOutput) {
-				cp.stdout.pipe(padStream(' ', 4)).pipe(process.stdout);
-				cp.stderr.pipe(padStream(' ', 4)).pipe(process.stderr);
+				var childStdout = cp.stdout;
+				var childStderr = cp.stderr;
+				if (!opts.omitLogIndentation) {
+					childStdout = childStdout.pipe(padStream(' ', 4));
+					childStderr = childStderr.pipe(padStream(' ', 4));
+				}
+				childStdout.pipe(process.stdout);
+				childStderr.pipe(process.stderr);
 			}
 
 			cpCache.push(cp);

--- a/test/test.js
+++ b/test/test.js
@@ -71,4 +71,30 @@ describe('concurrent', function () {
 			});
 		});
 	});
+
+	describe('`omitLogIndentation` option', function () {
+		var testOutput = 'omitLogIndentation test output';
+		var indentedTestOutput = '    ' + testOutput;
+
+		it('omits indentation when true', function (done) {
+			exec('grunt concurrent:omitLogIndentationTrue', function (error, stdout) {
+				assert.notEqual(stdout.split('\n').indexOf(testOutput), -1);
+				done();
+			});
+		});
+
+		it('indents output when false', function (done) {
+			exec('grunt concurrent:omitLogIndentationFalse', function (error, stdout) {
+				assert.notEqual(stdout.split('\n').indexOf(indentedTestOutput), -1);
+				done();
+			});
+		});
+
+		it('indents output by default', function (done) {
+			exec('grunt concurrent:omitLogIndentationDefault', function (error, stdout) {
+				assert.notEqual(stdout.split('\n').indexOf(indentedTestOutput), -1);
+				done();
+			});
+		});
+	});
 });


### PR DESCRIPTION
Add option to omit log indentation. One example use case is running mocha tests on TeamCity in parallel. Lock xo version to a version that existed at the time it was added to the project.