### PR TITLE
Add option to prepend each line of the output with the task name

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -13,13 +13,24 @@ module.exports = function (grunt) {
 				},
 				tasks: ['nodemon', 'watch']
 			},
-			testLogTaskName: {
+			testSimpleLogTaskName: {
 			  options: {
 			    logConcurrentOutput: {
 			      showTask: true
 			    }
 			  },
 			  tasks: ['test1', 'test2', 'test3']
+			},
+			testLogTaskName: {
+			  options: {
+			    logConcurrentOutput: {
+			      showTask: {
+			        maxLength: 7,
+			        colors: { 'test1': 'green', 'test2': 'blue', 'testargs1': 'yellow' }
+			      }
+			    }
+			  },
+			  tasks: ['test1', 'test2', 'testargs1']
 			},
 			colors: ['colorcheck']
 		},
@@ -110,6 +121,7 @@ module.exports = function (grunt) {
 		'clean',
 		'concurrent:test',
 		'concurrent:testSequence',
+		'concurrent:testSimpleLogTaskName',
 		'concurrent:testLogTaskName',
 		'simplemocha',
 		'clean'

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -13,10 +13,11 @@ module.exports = function (grunt) {
 				},
 				tasks: ['nodemon', 'watch']
 			},
-			logTaskName: {
+			testLogTaskName: {
 			  options: {
-			    logConcurrentOutput: true,
-			    logTaskName: true
+			    logConcurrentOutput: {
+			      showTask: true
+			    }
 			  },
 			  tasks: ['test1', 'test2', 'test3']
 			},
@@ -109,7 +110,7 @@ module.exports = function (grunt) {
 		'clean',
 		'concurrent:test',
 		'concurrent:testSequence',
-		'concurrent:logTaskName',
+		'concurrent:testLogTaskName',
 		'simplemocha',
 		'clean'
 	]);

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -26,7 +26,7 @@ module.exports = function (grunt) {
 			    logConcurrentOutput: {
 			      showTask: {
 			        maxLength: 7,
-			        colors: { 'test1': 'green', 'test2': 'blue', 'testargs1': 'yellow' }
+			        colors: { 'test1': 'green', 'test2': 'unknown-color', 'testargs1': 'yellow' }
 			      }
 			    }
 			  },

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -13,6 +13,13 @@ module.exports = function (grunt) {
 				},
 				tasks: ['nodemon', 'watch']
 			},
+			logTaskName: {
+			  options: {
+			    logConcurrentOutput: true,
+			    logTaskName: true
+			  },
+			  tasks: ['test1', 'test2', 'test3']
+			},
 			colors: ['colorcheck']
 		},
 		simplemocha: {
@@ -102,6 +109,7 @@ module.exports = function (grunt) {
 		'clean',
 		'concurrent:test',
 		'concurrent:testSequence',
+		'concurrent:logTaskName',
 		'simplemocha',
 		'clean'
 	]);

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "arrify": "^1.0.1",
     "async": "^1.2.1",
+    "colors": "^1.1.2",
     "indent-string": "^2.0.0",
     "pad-stream": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "arrify": "^1.0.1",
     "async": "^1.2.1",
-    "colors": "^1.1.2",
+    "chalk": "^2.0.1",
     "indent-string": "^2.0.0",
     "pad-stream": "^1.0.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,12 @@ grunt.registerTask('default', ['concurrent:target']);
 
 *The output will be messy when combining certain tasks. This option is best used with tasks that don't exit like `watch` and `nodemon` to monitor the output of long-running concurrent tasks.*
 
+### logTaskName
+
+Type: `boolean|number`<br>
+Default: `false`
+
+When logging the output of concurrent tasks with `logConcurrentOutput` you can set `logTaskName` to prepend the name of the task to the beginning of every output line. Specify a number to limit the maximum number of characters used for the task name.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ Limit how many tasks that are run concurrently.
 
 ### logConcurrentOutput
 
-Type: `boolean`<br>
+Type: `boolean|Object`<br>
 Default: `false`
 
 You can optionally log the output of your concurrent tasks by specifying the `logConcurrentOutput` option. Here is an example config which runs [grunt-nodemon](https://github.com/ChrisWren/grunt-nodemon) to launch and monitor a node server and [grunt-contrib-watch](https://github.com/gruntjs/grunt-contrib-watch) to watch for asset changes all in one terminal tab:
@@ -81,14 +81,46 @@ grunt.loadNpmTasks('grunt-concurrent');
 grunt.registerTask('default', ['concurrent:target']);
 ```
 
+To gather better information about task producing log output, you can use the `logConcurrentOutput.showTask` option (see below).
+
 *The output will be messy when combining certain tasks. This option is best used with tasks that don't exit like `watch` and `nodemon` to monitor the output of long-running concurrent tasks.*
 
-### logTaskName
+### logConcurrentOutput.showTask
 
 Type: `boolean|number`<br>
 Default: `false`
 
-When logging the output of concurrent tasks with `logConcurrentOutput` you can set `logTaskName` to prepend the name of the task to the beginning of every output line. Specify a number to limit the maximum number of characters used for the task name.
+You can optionally prepend current task name producing log output by specifying the `logConcurrentOutput.showTask` option.  
+
+```js
+grunt.initConfig({
+	concurrent: {
+		target: {
+			tasks: ['test1', 'test2', 'test3'],
+			options: {
+				logConcurrentOutput: { showTask: true }
+			}
+		}
+	}
+});
+```
+
+You can expand this option to limit task name length displayed :
+
+```js
+grunt.initConfig({
+	concurrent: {
+		target: {
+			tasks: ['test1', 'test2', 'testargs1'],
+			options: {
+				logConcurrentOutput: {
+				  showTask: 7
+				}
+			}
+		}
+	}
+});
+```
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -87,7 +87,7 @@ To gather better information about task producing log output, you can use the `l
 
 ### logConcurrentOutput.showTask
 
-Type: `boolean|number`<br>
+Type: `boolean|{color:Object|Array|Function, maxLength:number}`<br>
 Default: `false`
 
 You can optionally prepend current task name producing log output by specifying the `logConcurrentOutput.showTask` option.  
@@ -105,7 +105,7 @@ grunt.initConfig({
 });
 ```
 
-You can expand this option to limit task name length displayed :
+You can expand this option to define custom colors if default ones don't fit your needs, or to limit task name length displayed :
 
 ```js
 grunt.initConfig({
@@ -114,7 +114,10 @@ grunt.initConfig({
 			tasks: ['test1', 'test2', 'testargs1'],
 			options: {
 				logConcurrentOutput: {
-				  showTask: 7
+					showTask: {
+						maxLength: 7,
+						colors: { 'test1': 'green', 'test2': 'blue', 'testargs1': 'yellow' }
+					}
 				}
 			}
 		}

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -57,7 +57,7 @@ module.exports = function (grunt) {
 					var colorFn = colors.length > 0 ? chalk[colors.shift()] : function(s) { return s };//use an available color or none if more tasks then colors available
 					var maxLength = typeof opts.logTaskName === 'number' ?  opts.logTaskName : maxTaskLength;//use the longest task name as maximum, or the maximum provided by logTaskName
 					var paddingSpaces = (task.length > maxLength ? 0 : maxLength-task.length) + '[] '.length; //let output from all tasks be aligned
-					padString = '['+colorFn(task.slice(0,maxLength))+']'+(' '.repeat(paddingSpaces));
+					padString = colorFn('['+task.slice(0,maxLength)+']')+(' '.repeat(paddingSpaces));
 				} else {
 					padString = '    ';
 				}

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -58,7 +58,7 @@ module.exports = function (grunt) {
 					var colorFn = colors.length > 0 ? chalk[colors.shift()] : function(s) { return s };//use an available color or none if more tasks then colors available
 					var maxLength = typeof opts.logTaskName === 'number' ?  opts.logTaskName : Math.min(maxTaskLength,12);//task labels in output up to 12 characters
 					var numSpaces = (task.length > maxLength ? 0 : maxLength-task.length) + 3;//let output from all tasks be aligned
-                    padString = '['+colorFn(task.slice(0,maxLength))+']'+(' '.repeat(numSpaces));
+					padString = '['+colorFn(task.slice(0,maxLength))+']'+(' '.repeat(numSpaces));
 				} else {
 					padString = '    ';
 				}

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -16,7 +16,7 @@ module.exports = function (grunt) {
 		});
 		var tasks = this.data.tasks || this.data;
 		var maxTaskLength = Math.max.apply(null,(tasks.map(function(task){ return task.length})));
-		var colors = ["blue","magenta","yellow","green","red","cyan","gray"];
+		var taskColors = ["blue","magenta","yellow","green","red","cyan","gray"];
 		var flags = grunt.option.flags();
 
 		if (flags.indexOf('--no-color') === -1 &&
@@ -53,11 +53,17 @@ module.exports = function (grunt) {
 
 			if (opts.logConcurrentOutput) {
 				var padString;
-				if (opts.logTaskName) {
-					var colorFn = colors.length > 0 ? chalk[colors.shift()] : function(s) { return s };//use an available color or none if more tasks then colors available
-					var maxLength = typeof opts.logTaskName === 'number' ?  opts.logTaskName : maxTaskLength;//use the longest task name as maximum, or the maximum provided by logTaskName
+				if (opts.logConcurrentOutput.showTask) {
+					var color;
+					if(taskColors.length) { // task colors is a non-empty array => retrieving next available color
+						color = taskColors.shift();
+					} else {
+						color = null;
+					}
+					var colorizeFn = color ? chalk[color] : function(s) { return s };//use an available color or none if more tasks then colors available
+					var maxLength = typeof opts.logConcurrentOutput.showTask.maxLength === 'number' ? opts.logConcurrentOutput.showTask.maxLength : maxTaskLength;//use the longest task name as maximum, or the maximum provided by logConcurrentOutput.showTask
 					var paddingSpaces = (task.length > maxLength ? 0 : maxLength-task.length) + '[] '.length; //let output from all tasks be aligned
-					padString = colorFn('['+task.slice(0,maxLength)+']')+(' '.repeat(paddingSpaces));
+					padString = colorizeFn('['+task.slice(0,maxLength)+']')+(' '.repeat(paddingSpaces));
 				} else {
 					padString = '    ';
 				}

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -4,11 +4,11 @@ var padStream = require('pad-stream');
 var async = require('async');
 var arrify = require('arrify');
 var indentString = require('indent-string');
-var colors = require('colors');
+var chalk = require('chalk');
 
 var cpCache = [];
 
-var colorsAvailable = ["blue","magenta","yellow","green","red","cyan","white","gray"];
+var colors = ["blue","magenta","yellow","green","red","cyan","white","gray","redBright","greenBright","yellowBright","blueBright","magentaBright","cyanBright"];
 
 module.exports = function (grunt) {
 	grunt.registerMultiTask('concurrent', 'Run grunt tasks concurrently', function () {
@@ -53,21 +53,18 @@ module.exports = function (grunt) {
 			});
 
 			if (opts.logConcurrentOutput) {
-				var taskLabel,numSpaces;
-				if(opts.logTaskName)
-				{
-					var colorFn = colorsAvailable.length > 0 ? colors[colorsAvailable.shift()] : function(s) { return s };//use an available color or none if more tasks then colors available
+				var padString;
+				if (opts.logTaskName) {
+					var colorFn = colors.length > 0 ? chalk[colors.shift()] : function(s) { return s };//use an available color or none if more tasks then colors available
 					var maxLength = typeof opts.logTaskName === 'number' ?  opts.logTaskName : Math.min(maxTaskLength,12);//task labels in output up to 12 characters
-					taskLabel = '['+colorFn(task.substr(0,maxLength))+']';
-					numSpaces = (task.length > maxLength ? 0 : maxLength-task.length) + 3;//let output from all tasks be aligned
+					var numSpaces = (task.length > maxLength ? 0 : maxLength-task.length) + 3;//let output from all tasks be aligned
+                    padString = '['+colorFn(task.slice(0,maxLength))+']'+(' '.repeat(numSpaces));
+				} else {
+					padString = '    ';
 				}
-				else
-				{
-					taskLabel = '';
-					numSpaces = 4;
-				}
-				cp.stdout.pipe(padStream(' ', numSpaces)).pipe(padStream(taskLabel, 1)).pipe(process.stdout);
-				cp.stderr.pipe(padStream(' ', numSpaces)).pipe(padStream(taskLabel, 1)).pipe(process.stderr);
+
+				cp.stdout.pipe(padStream(padString, 1)).pipe(process.stdout);
+				cp.stderr.pipe(padStream(padString, 1)).pipe(process.stderr);
 			}
 
 			cpCache.push(cp);

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -53,19 +53,19 @@ module.exports = function (grunt) {
 			});
 
 			if (opts.logConcurrentOutput) {
-                var taskLabel,numSpaces;
-			    if(opts.logTaskName)
-                {
-                    var colorFn = colorsAvailable.length > 0 ? colors[colorsAvailable.shift()] : function(s) { return s };//use an available color or none if more tasks then colors available
-                    var maxLength = typeof opts.logTaskName === 'number' ?  opts.logTaskName : Math.min(maxTaskLength,12);//task labels in output up to 12 characters
-                    taskLabel = '['+colorFn(task.substr(0,maxLength))+']';
-                    numSpaces = (task.length > maxLength ? 0 : maxLength-task.length) + 3;//let output from all tasks be aligned
-                }
-                else
-                {
-                    taskLabel = '';
-                    numSpaces = 4;
-                }
+				var taskLabel,numSpaces;
+				if(opts.logTaskName)
+				{
+					var colorFn = colorsAvailable.length > 0 ? colors[colorsAvailable.shift()] : function(s) { return s };//use an available color or none if more tasks then colors available
+					var maxLength = typeof opts.logTaskName === 'number' ?  opts.logTaskName : Math.min(maxTaskLength,12);//task labels in output up to 12 characters
+					taskLabel = '['+colorFn(task.substr(0,maxLength))+']';
+					numSpaces = (task.length > maxLength ? 0 : maxLength-task.length) + 3;//let output from all tasks be aligned
+				}
+				else
+				{
+					taskLabel = '';
+					numSpaces = 4;
+				}
 				cp.stdout.pipe(padStream(' ', numSpaces)).pipe(padStream(taskLabel, 1)).pipe(process.stdout);
 				cp.stderr.pipe(padStream(' ', numSpaces)).pipe(padStream(taskLabel, 1)).pipe(process.stderr);
 			}

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -17,6 +17,9 @@ module.exports = function (grunt) {
 		var tasks = this.data.tasks || this.data;
 		var maxTaskLength = Math.max.apply(null,(tasks.map(function(task){ return task.length})));
 		var taskColors = ["blue","magenta","yellow","green","red","cyan","gray"];
+		if(opts.logConcurrentOutput && opts.logConcurrentOutput.showTask && opts.logConcurrentOutput.showTask.colors) {
+			taskColors = opts.logConcurrentOutput.showTask.colors;
+		}
 		var flags = grunt.option.flags();
 
 		if (flags.indexOf('--no-color') === -1 &&
@@ -57,11 +60,15 @@ module.exports = function (grunt) {
 					var color;
 					if(taskColors.length) { // task colors is a non-empty array => retrieving next available color
 						color = taskColors.shift();
+					} else if(taskColors[task]) { // task colors is a map[taskName]:color containing current task
+						color = taskColors[task];
+					} else if(typeof taskColors === 'function') { // task colors is a function, resolving color by task name
+						color = taskColors(task);
 					} else {
 						color = null;
 					}
 					var colorizeFn = color ? chalk[color] : function(s) { return s };//use an available color or none if more tasks then colors available
-					var maxLength = typeof opts.logConcurrentOutput.showTask.maxLength === 'number' ? opts.logConcurrentOutput.showTask.maxLength : maxTaskLength;//use the longest task name as maximum, or the maximum provided by logConcurrentOutput.showTask
+					var maxLength = opts.logConcurrentOutput.showTask.maxLength || maxTaskLength;//use the longest task name as maximum, or the maximum provided by logConcurrentOutput.showTask.maxLength
 					var paddingSpaces = (task.length > maxLength ? 0 : maxLength-task.length) + '[] '.length; //let output from all tasks be aligned
 					padString = colorizeFn('['+task.slice(0,maxLength)+']')+(' '.repeat(paddingSpaces));
 				} else {

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -16,7 +16,7 @@ module.exports = function (grunt) {
 		});
 		var tasks = this.data.tasks || this.data;
 		var maxTaskLength = Math.max.apply(null,(tasks.map(function(task){ return task.length})));
-		var colors = ["blue","magenta","yellow","green","red","cyan","white","gray"];
+		var colors = ["blue","magenta","yellow","green","red","cyan","gray"];
 		var flags = grunt.option.flags();
 
 		if (flags.indexOf('--no-color') === -1 &&

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -56,8 +56,8 @@ module.exports = function (grunt) {
 				if (opts.logTaskName) {
 					var colorFn = colors.length > 0 ? chalk[colors.shift()] : function(s) { return s };//use an available color or none if more tasks then colors available
 					var maxLength = typeof opts.logTaskName === 'number' ?  opts.logTaskName : maxTaskLength;//use the longest task name as maximum, or the maximum provided by logTaskName
-					var numSpaces = (task.length > maxLength ? 0 : maxLength-task.length) + 3;//let output from all tasks be aligned
-					padString = '['+colorFn(task.slice(0,maxLength))+']'+(' '.repeat(numSpaces));
+					var paddingSpaces = (task.length > maxLength ? 0 : maxLength-task.length) + '[] '.length; //let output from all tasks be aligned
+					padString = '['+colorFn(task.slice(0,maxLength))+']'+(' '.repeat(paddingSpaces));
 				} else {
 					padString = '    ';
 				}

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -67,6 +67,10 @@ module.exports = function (grunt) {
 					} else {
 						color = null;
 					}
+					if(color && !chalk[color]) {
+						grunt.log.error("No chalk color found corresponding to ["+color+"] => falling back to uncolored task ["+task+"]");
+						color = null;
+					}
 					var colorizeFn = color ? chalk[color] : function(s) { return s };//use an available color or none if more tasks then colors available
 					var maxLength = opts.logConcurrentOutput.showTask.maxLength || maxTaskLength;//use the longest task name as maximum, or the maximum provided by logConcurrentOutput.showTask.maxLength
 					var paddingSpaces = (task.length > maxLength ? 0 : maxLength-task.length) + '[] '.length; //let output from all tasks be aligned

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -8,8 +8,6 @@ var chalk = require('chalk');
 
 var cpCache = [];
 
-var colors = ["blue","magenta","yellow","green","red","cyan","white","gray","redBright","greenBright","yellowBright","blueBright","magentaBright","cyanBright"];
-
 module.exports = function (grunt) {
 	grunt.registerMultiTask('concurrent', 'Run grunt tasks concurrently', function () {
 		var cb = this.async();
@@ -18,6 +16,7 @@ module.exports = function (grunt) {
 		});
 		var tasks = this.data.tasks || this.data;
 		var maxTaskLength = Math.max.apply(null,(tasks.map(function(task){ return task.length})));
+		var colors = ["blue","magenta","yellow","green","red","cyan","white","gray"];
 		var flags = grunt.option.flags();
 
 		if (flags.indexOf('--no-color') === -1 &&
@@ -56,7 +55,7 @@ module.exports = function (grunt) {
 				var padString;
 				if (opts.logTaskName) {
 					var colorFn = colors.length > 0 ? chalk[colors.shift()] : function(s) { return s };//use an available color or none if more tasks then colors available
-					var maxLength = typeof opts.logTaskName === 'number' ?  opts.logTaskName : Math.min(maxTaskLength,12);//task labels in output up to 12 characters
+					var maxLength = typeof opts.logTaskName === 'number' ?  opts.logTaskName : maxTaskLength;//use the longest task name as maximum, or the maximum provided by logTaskName
 					var numSpaces = (task.length > maxLength ? 0 : maxLength-task.length) + 3;//let output from all tasks be aligned
 					padString = '['+colorFn(task.slice(0,maxLength))+']'+(' '.repeat(numSpaces));
 				} else {


### PR DESCRIPTION
Same as https://github.com/sindresorhus/grunt-concurrent/pull/95, but with fixed changes requested and some more tuning, like the possibility to customize task colors per task name.

/cc @flyon