### PR TITLE
Adds option to prepend task name to concurrent outputs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,15 @@ grunt.registerTask('default', ['concurrent:target']);
 
 *The output will be messy when combining certain tasks. This option is best used with tasks that don't exit like `watch` and `nodemon` to monitor the output of long-running concurrent tasks.*
 
+### logTaskName
+
+Type: `boolean`<br>
+Default: `false`
+
+If using the `logConcurrentOutput` option, adding the `logTaskName` option
+will prepend all concurrent log outputs with the name of the task that generated
+said output. While the output will still be messy -- as noted above -- this
+allows for simplified log parsing when `grunt-concurrent` is used in build tasks.
 
 ## License
 

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -49,7 +49,8 @@ module.exports = function (grunt) {
 			});
 
 			if (opts.logConcurrentOutput) {
-				var padding = opts.logTaskName ? `${task} ` : '    ';
+				var delimiter = opts.delimiter || ' ';
+				var padding = opts.logTaskName ? `${task}${delimiter}` : '    ';
 
 				cp.stdout.pipe(padStream(padding, 1)).pipe(process.stdout);
 				cp.stderr.pipe(padStream(padding, 1)).pipe(process.stderr);

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -49,8 +49,10 @@ module.exports = function (grunt) {
 			});
 
 			if (opts.logConcurrentOutput) {
-				cp.stdout.pipe(padStream(' ', 4)).pipe(process.stdout);
-				cp.stderr.pipe(padStream(' ', 4)).pipe(process.stderr);
+				var padding = opts.logTaskName ? `${task} ` : '    ';
+
+				cp.stdout.pipe(padStream(padding, 1)).pipe(process.stdout);
+				cp.stderr.pipe(padStream(padding, 1)).pipe(process.stderr);
 			}
 
 			cpCache.push(cp);


### PR DESCRIPTION
In order to simplify parsing the outputs of several concurrently running tasks, I added the `logTaskName` option. When enabled, the task name (as listed in the tasks array provided in grunt task configuration) is listed before the log output of that task.