### PR TITLE
Add `indent` option

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -30,6 +30,34 @@ module.exports = grunt => {
 			},
 			colors: [
 				'colorcheck'
+			],
+			indentTrue: {
+				options: {
+					indent: true
+				},
+				tasks: [
+					'testIndent'
+				]
+			},
+			indentFalse: {
+				options: {
+					indent: false
+				},
+				tasks: [
+					'testIndent'
+				]
+			},
+			indentFalseConcurrentOutput: {
+				options: {
+					logConcurrentOutput: true,
+					indent: false
+				},
+				tasks: [
+					'testIndent'
+				]
+			},
+			indentDefault: [
+				'testIndent'
 			]
 		},
 		simplemocha: {
@@ -119,6 +147,10 @@ module.exports = grunt => {
 		// Writes 'true' or 'false' to the file
 		const supports = String(Boolean(supportsColor.stdout));
 		grunt.file.write('test/tmp/colors', supports);
+	});
+
+	grunt.registerTask('testIndent', () => {
+		console.log('indent test output');
 	});
 
 	grunt.registerTask('default', [

--- a/readme.md
+++ b/readme.md
@@ -82,4 +82,4 @@ grunt.registerTask('default', ['concurrent:target']);
 Type: `boolean`<br>
 Default: `true`
 
-You can optionally skip indenting the log output of your concurrent tasks by specifying the `indent` option as `false`. This can be useful for running tasks in parallel for a stdout parser which expects no indentation, e.g. TeamCity tests.
+You can optionally skip indenting the log output of your concurrent tasks by specifying `false`. This can be useful for running tasks in parallel for a stdout parser which expects no indentation, for example, TeamCity tests.

--- a/readme.md
+++ b/readme.md
@@ -76,3 +76,10 @@ grunt.registerTask('default', ['concurrent:target']);
 ```
 
 *The output will be messy when combining certain tasks. This option is best used with tasks that don't exit like `watch` and `nodemon` to monitor the output of long-running concurrent tasks.*
+
+### indent
+
+Type: `boolean`<br>
+Default: `true`
+
+You can optionally skip indenting the log output of your concurrent tasks by specifying the `indent` option as `false`. This can be useful for running tasks in parallel for a stdout parser which expects no indentation, e.g. TeamCity tests.

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -12,7 +12,8 @@ module.exports = grunt => {
 		const done = this.async();
 
 		const options = this.options({
-			limit: Math.max((os.cpus().length || 1) * 2, 2)
+			limit: Math.max((os.cpus().length || 1) * 2, 2),
+			indent: true
 		});
 
 		const tasks = this.data.tasks || this.data;
@@ -47,15 +48,27 @@ module.exports = grunt => {
 				}
 			}, (error, result) => {
 				if (!options.logConcurrentOutput) {
-					grunt.log.writeln('\n' + indentString(result.stdout + result.stderr, 4));
+					let output = result.stdout + result.stderr;
+					if (options.indent) {
+						output = indentString(output, 4);
+					}
+
+					grunt.log.writeln('\n' + output);
 				}
 
 				next(error);
 			});
 
 			if (options.logConcurrentOutput) {
-				subprocess.stdout.pipe(padStream(4)).pipe(process.stdout);
-				subprocess.stderr.pipe(padStream(4)).pipe(process.stderr);
+				let subStdout = subprocess.stdout;
+				let subStderr = subprocess.stderr;
+				if (options.indent) {
+					subStdout = subStdout.pipe(padStream(4));
+					subStderr = subStderr.pipe(padStream(4));
+				}
+
+				subStdout.pipe(process.stdout);
+				subStderr.pipe(process.stderr);
 			}
 
 			subprocesses.push(subprocess);

--- a/tasks/concurrent.js
+++ b/tasks/concurrent.js
@@ -53,7 +53,7 @@ module.exports = grunt => {
 						output = indentString(output, 4);
 					}
 
-					grunt.log.writeln('\n' + output);
+					grunt.log.writeln(`\n${output}`);
 				}
 
 				next(error);

--- a/test/test.js
+++ b/test/test.js
@@ -71,4 +71,37 @@ describe('concurrent', () => {
 			});
 		});
 	});
+
+	describe('`indent` option', () => {
+		const testOutput = 'indent test output';
+		const indentedTestOutput = '    ' + testOutput;
+
+		it('indents output when true', done => {
+			exec('grunt concurrent:indentTrue', (error, stdout) => {
+				assert.ok(stdout.split('\n').includes(indentedTestOutput));
+				done();
+			});
+		});
+
+		it('does not indent output when false', done => {
+			exec('grunt concurrent:indentFalse', (error, stdout) => {
+				assert.ok(stdout.split('\n').includes(testOutput));
+				done();
+			});
+		});
+
+		it('does not indent output when false and logConcurrentOutput is true', done => {
+			exec('grunt concurrent:indentFalseConcurrentOutput', (error, stdout) => {
+				assert.ok(stdout.split('\n').includes(testOutput));
+				done();
+			});
+		});
+
+		it('indents output by default', done => {
+			exec('grunt concurrent:indentDefault', (error, stdout) => {
+				assert.ok(stdout.split('\n').includes(indentedTestOutput));
+				done();
+			});
+		});
+	});
 });


### PR DESCRIPTION
Skipping indentation is needed for TeamCity's test parsing.

This is a remake of https://github.com/sindresorhus/grunt-concurrent/pull/98.